### PR TITLE
any belief updater can be used with DESPOT as the policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.clone("https://github.com/JuliaPOMDP/POMDPToolbox.jl"); Pkg.clone("https://github.com/JuliaPOMDP/GenerativeModels.jl"); Pkg.build("DESPOT");'
   - julia -e 'include(Pkg.dir("DESPOT", "test", "build.jl"))'
-  - julia --check-bounds -e 'Pkg.test("DESPOT"; coverage=true)'
+  - julia --check-bounds=yes -e 'Pkg.test("DESPOT"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("DESPOT")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script:
   - export PATH=$HOME/.local/bin:$PATH
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.clone("https://github.com/JuliaPOMDP/POMDPToolbox.jl"); Pkg.clone("https://github.com/JuliaPOMDP/GenerativeModels.jl"); Pkg.build("DESPOT"); Pkg.test("DESPOT"; coverage=true)'
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.clone("https://github.com/JuliaPOMDP/POMDPToolbox.jl"); Pkg.clone("https://github.com/JuliaPOMDP/GenerativeModels.jl"); Pkg.build("DESPOT");'
+  - julia -e 'include(Pkg.dir("DESPOT", "test", "build.jl"))'
+  - julia --check-bounds -e 'Pkg.test("DESPOT"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("DESPOT")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/src/beliefUpdate/beliefUpdateParticle.jl
+++ b/src/beliefUpdate/beliefUpdateParticle.jl
@@ -79,6 +79,23 @@ function initialize_belief{S,A,O}(bu::DESPOTBeliefUpdater{S,A,O},
     return new_belief
 end
 
+#XXX this could probably be combined with the method above or made more efficient without the sample_particles!
+function initialize_belief{S}(bu::DESPOTBeliefUpdater{S}, b)
+    new_belief = create_belief(bu)
+
+    pool = Array(DESPOTParticle{S}, n_particles)
+    w = 1.0/bu.n_particles
+    for i in 1:bu.n_particles
+        pool[i] = DESPOTParticle{S}(rand(bu.rng, b), i, w)
+    end
+
+    DESPOT.sample_particles!(new_belief.particles,
+                             pool,
+                             bu.n_particles,
+                             bu.belief_update_seed,
+                             bu.rand_max)
+end
+
 function normalize!{S}(particles::Vector{DESPOTParticle{S}}) 
     prob_sum = 0.0
     for p in particles

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -8,8 +8,8 @@ type DESPOTSolver{S,A,O,L,U} <: POMDPs.Solver
     root_default_action::A
     node_count::Int64
     config::DESPOTConfig
+    rng::AbstractRNG
     #preallocated for simulations
-    rng::DESPOT.DESPOTRandomNumber
     curr_reward::DESPOTReward
     next_state::S
     curr_obs::O
@@ -18,6 +18,7 @@ type DESPOTSolver{S,A,O,L,U} <: POMDPs.Solver
     function DESPOTSolver(  ;
                             lb::DESPOTLowerBound{S,A,O} = L(),
                             ub::DESPOTUpperBound{S,A,O} = U(),
+                            rng::AbstractRNG = Base.GLOBAL_RNG,
                             search_depth::Int64 = 90,
                             main_seed::UInt32 = convert(UInt32, 42),
                             time_per_move::Float64 = 1.0,                 # sec
@@ -56,7 +57,7 @@ type DESPOTSolver{S,A,O,L,U} <: POMDPs.Solver
         this.config.rand_max = rand_max
         this.config.debug = debug        
         this.root_default_action = root_default_action
-        this.rng = DESPOTRandomNumber(-1)
+        this.rng = rng
         this.next_state = next_state
         this.curr_obs = curr_obs
         this.curr_reward = 0.0
@@ -266,9 +267,8 @@ function step{S,A,O,L,U}(solver::DESPOTSolver{S,A,O,L,U},
               rand_num::Float64,
               action::A)
               
-    solver.rng.number = rand_num
     solver.next_state, solver.curr_obs, solver.curr_reward =
-        GenerativeModels.generate_sor(pomdp, state, action, solver.rng)
+        GenerativeModels.generate_sor(pomdp, state, action, DESPOTRandomNumber(rand_num))
 
     return nothing
 end

--- a/test/build.jl
+++ b/test/build.jl
@@ -1,3 +1,5 @@
+Pkg.checkout("POMDPs")
+
 using POMDPs
 
 POMDPs.add("ParticleFilters")

--- a/test/build.jl
+++ b/test/build.jl
@@ -1,0 +1,3 @@
+using POMDPs
+
+POMDPs.add("ParticleFilters")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ end
 
 # Test on a simple RockSample problem
 include("../src/problems/RockSample/runRockSample.jl")
+# include("test_with_other_particle_filter.jl")
 
 # Common problem parameters
 n_particles             = 500 # for both solver and belief updater

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ end
 
 # Test on a simple RockSample problem
 include("../src/problems/RockSample/runRockSample.jl")
-# include("test_with_other_particle_filter.jl")
+include("test_with_other_particle_filter.jl")
 
 # Common problem parameters
 n_particles             = 500 # for both solver and belief updater

--- a/test/test_with_other_particle_filter.jl
+++ b/test/test_with_other_particle_filter.jl
@@ -1,0 +1,24 @@
+using ParticleFilters
+
+pomdp = RockSample(4, 4)
+
+filter = SIRParticleFilter(pomdp, 500)
+
+custom_lb = RockSampleParticleLB{RockSampleState, RockSampleAction, RockSampleObs}(pomdp) # custom lower bound to use with DESPOT solver
+custom_ub = UpperBoundNonStochastic{RockSampleState, RockSampleAction, RockSampleObs}(pomdp)
+  
+solver = DESPOTSolver{RockSampleState,
+                      RockSampleAction,
+                      RockSampleObs,
+                      RockSampleParticleLB,
+                      UpperBoundNonStochastic}(lb = custom_lb,
+                                               ub = custom_ub,
+                                               n_particles = 500,
+                                               max_trials = -1
+                                              )
+
+policy = solve(solver, pomdp)
+
+ro = RolloutSimulator(max_steps=10, rng=MersenneTwister(1))
+
+simulate(ro, pomdp, policy, filter)


### PR DESCRIPTION
When action(policy, b) is called for a b that is not a DESPOTBelief, a DESPOTBelief is simply constructed from b and used to choose the action.

I commented out the actual test for this because ParticleFilters.jl is not easy to set up on Travis yet, but I did test it on my machine.