### PR TITLE
POMDPs compatibility and visualization

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 POMDPs 0.4
 Distributions
+JSON

--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,9 @@
-Sat 18 Feb 2017 03:13:56 PM PST
+Sat 18 Feb 2017 04:19:42 PM PST
 
-(before this)
+Added visualization
+
+Sat 18 Feb 2017 03:13:56 PM PST (before this, besides pull requests)
+
 got rid of action
 got rid of isterminal - isterminal_obs check
+changed pomdp.discount to discount(pomdp) in many places

--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,5 @@
+Sat 18 Feb 2017 03:13:56 PM PST
+
+(before this)
+got rid of action
+got rid of isterminal - isterminal_obs check

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,2 +1,3 @@
 using POMDPs
 POMDPs.add("GenerativeModels")
+POMDPs.add("MCTS") # for visualization

--- a/src/DESPOT.jl
+++ b/src/DESPOT.jl
@@ -123,7 +123,7 @@ function action{S,A,O}(p::DESPOTPolicy{S,A,O}, b)
 end
 
 function solve{S,A,O,L,U}(solver::DESPOTSolver{S,A,O,L,U}, pomdp::POMDPs.POMDP{S,A,O})
-    @warn_requirements solve(solver, pomdp)
+    @warn_requirements solve(solver, pomdp) 
     policy = DESPOTPolicy(solver, pomdp)
     init_solver(solver, pomdp)
     return policy

--- a/src/DESPOT.jl
+++ b/src/DESPOT.jl
@@ -173,6 +173,11 @@ export
     init_lower_bound,
     init_upper_bound,
     fringe_upper_bound,
-    sample_particles! #TODO: need a better way of doing this, perhaps put in POMDPutils
+    sample_particles!, #TODO: need a better way of doing this, perhaps put in POMDPutils
+    ########## Visualization ##########
+    blink,
+    DESPOTVisualizer
     
+include("visualization.jl")
+
 end #module

--- a/src/DESPOT.jl
+++ b/src/DESPOT.jl
@@ -75,6 +75,8 @@ end
 
 create_policy{S,A,O,B}(solver::DESPOTSolver{S,A,O,B}, pomdp::POMDPs.POMDP{S,A,O}) = DESPOTPolicy(solver, pomdp)
 
+# Bounds interface
+
 bounds{S,A,O,B}(bounds::B,
             pomdp::POMDP{S,A,O},
             particles::Vector{DESPOTParticle{S}},
@@ -84,6 +86,14 @@ bounds{S,A,O,B}(bounds::B,
 init_bounds{S,A,O,B}(bounds::B,
             pomdp::POMDPs.POMDP{S,A,O},
             config::DESPOTConfig) = nothing
+
+# this may change
+"""
+    default_action(bounds, pomdp::POMDP, particles::Vector, config::DESPOTConfig)
+
+Return an action for the case when an action was not determined by the solver. This could be, for example, the best action from the lower bound calculation.
+"""
+function default_action end
 
 # FUNCTIONS
 
@@ -119,12 +129,10 @@ end
     A = action_type(P)
     O = obs_type(P)
     @req actions(::P)
-    @req transition(::P,::S,::A)
-    @req observation(::P,::S,::A,::S)    
+    @req generate_sor(::P,::S,::A,::typeof(create_rng(solver.random_streams)))
     @req reward(::P,::S,::A,::S)
     @req discount(::P)    
     @req isterminal(::P,::S)
-    @req isterminal_obs(::P,::O)
     as = actions(pomdp)
     @req iterator(::typeof(as))    
 end

--- a/src/DESPOT.jl
+++ b/src/DESPOT.jl
@@ -137,6 +137,8 @@ end
     @req iterator(::typeof(as))    
 end
 
+include("visualization.jl")
+
 export
     ################## DESPOT TYPES ##################
     DESPOTSolver,
@@ -165,6 +167,9 @@ export
     ########## UPPER AND LOWER BOUND METHODS #########
     bounds,
     init_bounds,
-    sample_particles! #TODO: need a better way of doing this, perhaps put in POMDPutils
+    sample_particles!, #TODO: need a better way of doing this, perhaps put in POMDPutils
+    ########## Visualization #######
+    blink,
+    DESPOTVisualizer
     
 end #module

--- a/src/DESPOT.jl
+++ b/src/DESPOT.jl
@@ -92,13 +92,11 @@ upper_bound{S,A,O}(ub::DESPOTUpperBound{S,A,O},
     
 init_lower_bound{S,A,O}(lb::DESPOTLowerBound{S,A,O},
                     pomdp::POMDPs.POMDP{S,A,O},
-                    config::DESPOTConfig) =
-    error("$(typeof(lb)) bound does not implement init_lower_bound")                    
+                    config::DESPOTConfig) = lb
     
 init_upper_bound{S,A,O}(ub::DESPOTUpperBound{S,A,O},
                     pomdp::POMDPs.POMDP{S,A,O},
-                    config::DESPOTConfig) =
-    error("$(typeof(ub)) bound does not implement init_upper_bound")
+                    config::DESPOTConfig) = ub
     
 fringe_upper_bound{S,A,O}(pomdp::POMDP{S,A,O}, state::S) = 
     error("$(typeof(pomdp)) does not implement fringe_upper_bound")

--- a/src/beliefUpdate/beliefUpdateParticle.jl
+++ b/src/beliefUpdate/beliefUpdateParticle.jl
@@ -1,10 +1,10 @@
-import POMDPs: update, initialize_belief
+import POMDPs: update, initialize_belief, updater
 using DESPOT
 
 type DESPOTBeliefUpdater{S,A,O} <: POMDPs.Updater
     pomdp::POMDP
     num_updates::Int64
-    rng::DESPOTDefaultRNG
+    rng::AbstractRNG
     seed::UInt32
     rand_max::Int64
     belief_update_seed::UInt32
@@ -25,20 +25,24 @@ type DESPOTBeliefUpdater{S,A,O} <: POMDPs.Updater
                                  rand_max::Int64 = 2147483647,
                                  n_particles = 500,
                                  particle_weight_threshold::Float64 = 1e-20,
-                                 eff_particle_fraction::Float64 = 0.05)
+                                 eff_particle_fraction::Float64 = 0.05,
+                                 next_state::S = S(),
+                                 observation::O = O(),
+                                 rng::AbstractRNG=DESPOTDefaultRNG(convert(UInt32, seed $ (n_particles+1)), rand_max)
+                                )
         this = new()
         this.pomdp = pomdp
         this.num_updates = 0                               
         this.belief_update_seed = seed $ (n_particles + 1)       
-        this.rng = DESPOTDefaultRNG(this.belief_update_seed, rand_max)
+        this.rng = rng
         this.rand_max = rand_max
         this.particle_weight_threshold = particle_weight_threshold
         this.eff_particle_fraction = eff_particle_fraction
         this.n_particles = n_particles
         
         # init preallocated variables
-         this.next_state = S()
-         this.observation = O()
+        this.next_state = next_state
+        this.observation = observation
         this.new_particle = DESPOTParticle{S}(this.next_state, 1, 1) #placeholder
         this.n_sampled = 0
         this.obs_probability = -1.0
@@ -83,7 +87,7 @@ end
 function initialize_belief{S}(bu::DESPOTBeliefUpdater{S}, b)
     new_belief = create_belief(bu)
 
-    pool = Array(DESPOTParticle{S}, n_particles)
+    pool = Array(DESPOTParticle{S}, bu.n_particles)
     w = 1.0/bu.n_particles
     for i in 1:bu.n_particles
         pool[i] = DESPOTParticle{S}(rand(bu.rng, b), i, w)
@@ -94,7 +98,16 @@ function initialize_belief{S}(bu::DESPOTBeliefUpdater{S}, b)
                              bu.n_particles,
                              bu.belief_update_seed,
                              bu.rand_max)
+
+    return new_belief
 end
+
+updater{S,A,O}(p::DESPOTPolicy{S,A,O}) = DESPOTBeliefUpdater{S,A,O}(p.pomdp,
+                                                                    n_particles=p.solver.config.n_particles,
+                                                                    next_state=p.solver.next_state,
+                                                                    observation=p.solver.curr_obs,
+                                                                    rng=p.solver.rng
+                                                                   )
 
 function normalize!{S}(particles::Vector{DESPOTParticle{S}}) 
     prob_sum = 0.0
@@ -120,11 +133,18 @@ function update{S,A,O}(bu::DESPOTBeliefUpdater{S,A,O},
     updated_belief.particles = []
 
     #reset RNG
-    bu.rng = DESPOTDefaultRNG(bu.belief_update_seed, bu.rand_max)
+    if isa(bu.rng, DESPOTDefaultRNG)
+        bu.rng = DESPOTDefaultRNG(bu.belief_update_seed, bu.rand_max)
+    end
 
     for p in current_belief.particles
         rand!(bu.rng, random_number)
-        rng = DESPOTRandomNumber(random_number[1])
+
+        if isa(bu.rng, DESPOTDefaultRNG)
+            rng = DESPOTRandomNumber(random_number[1])
+        else
+            rng = bu.rng
+        end
         
         bu.next_state = GenerativeModels.generate_s(bu.pomdp, p.state, action, rng)
 

--- a/src/history.jl
+++ b/src/history.jl
@@ -1,4 +1,3 @@
-
 type History{A,O}
     actions::Vector{A}
     observations::Vector{O}

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -59,7 +59,7 @@ type _QNode{S,A,O,L,U,T} #Workaround to achieve a circular type definition
                 this.weight_sum += obs_weight_sum
                 add(this.history, action, obs)
                 remove_last(this.history)
-                this.obs_to_node[obs], a::A = VNode{S,A,O,L,U}(
+                this.obs_to_node[obs] = VNode{S,A,O,L,U}(
                                             pomdp,
                                             particles,
                                             lb,
@@ -115,18 +115,13 @@ type VNode{S,A,O,L,U}
 
         this = new()
         this.particles          = particles
-        this.lbound, a::A       = DESPOT.lower_bound(
-                                                lb,
-                                                pomdp,
-                                                particles,
-                                                ub.upper_bound_act,
-                                                config)
+        this.lbound             = DESPOT.lower_bound(lb, pomdp, particles, config)
         this.ubound             = upper_bound(ub, pomdp, particles, config)     
         this.depth              = depth
         this.default_value      = this.lbound
-        this.pruned_action      = A()
+        # this.pruned_action      = A()
         this.weight             = weight
-        this.best_ub_action     = A()
+        # this.best_ub_action     = A()
         this.in_tree            = in_tree
         this.n_tree_nodes       = in_tree ? 1:0
         this.q_nodes            = Dict{A,QNode{S,A,O,L,U}}()
@@ -135,7 +130,7 @@ type VNode{S,A,O,L,U}
         this.q_star             = -Inf
         
         validate_bounds(this.lbound, this.ubound, config)
-        return this,a
+        return this
   end
 end
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -165,7 +165,7 @@ end
 # end
 
 function get_lb_action{S,A,O,L,U}(node::VNode{S,A,O,L,U}, config::DESPOTConfig, discount::Float64)
-  a_star = A()
+  local a_star
   q_star::Float64 = -Inf
   remaining_reward::Float64 = 0.0
   

--- a/src/problems/RockSample/rockSampleBounds.jl
+++ b/src/problems/RockSample/rockSampleBounds.jl
@@ -3,7 +3,7 @@ include("rockSampleParticleLB.jl")
 include("rockSampleFringeUB.jl")
 include("../../upperBound/upperBoundNonStochastic.jl")
 
-import DESPOT: bounds, init_bounds
+import DESPOT: bounds, init_bounds, default_action
 
 type RockSampleBounds
     lb::RockSampleParticleLB
@@ -32,4 +32,9 @@ end
 function init_bounds(bounds::RockSampleBounds, pomdp::RockSample, config::DESPOTConfig)
     init_bound(bounds.ub, pomdp, config)
     # lower bound init not currently needed
+end
+
+function default_action(b::RockSampleBounds, pomdp::RockSample, particles::Vector, config::DESPOTConfig)
+    bounds(b, pomdp, particles, config)
+    return b.lb.best_action
 end

--- a/src/problems/RockSample/runRockSample.jl
+++ b/src/problems/RockSample/runRockSample.jl
@@ -135,7 +135,9 @@ function execute(;
     solver::DESPOTSolver = DESPOTSolver{RockSampleState,
                                         RockSampleAction,
                                         RockSampleObs,
-                                        RockSampleBounds}(
+                                        RockSampleBounds,
+                                        RandomStreams
+                                       }(
                                # specify the optional keyword parameters
                                bounds = custom_bounds,
                                search_depth = search_depth,                                                                                       

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -1,8 +1,8 @@
 
-type DESPOTSolver{S,A,O,B} <: POMDPs.Solver
+type DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
     belief::DESPOTBelief{S,A,O}
     bounds::B
-    random_streams
+    random_streams::RS
     root::VNode{S,A,O,B}
     node_count::Int64
     config::DESPOTConfig
@@ -28,7 +28,7 @@ type DESPOTSolver{S,A,O,B} <: POMDPs.Solver
                             max_trials::Int64 = -1,
                             rand_max::Int64 = 2147483647,
                             debug::Int64 = 0,
-                            random_streams = RandomStreams(n_particles, search_depth, main_seed),
+                            random_streams::RS = RandomStreams(n_particles, search_depth, main_seed),
                             next_state = S(),
                             curr_obs = O()
                            )

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -83,7 +83,7 @@ function new_root{S,A,O,L,U}(solver::DESPOTSolver{S,A,O,L,U},
                   belief::DESPOTBelief{S})
     
     solver.belief = belief
-    solver.root, solver.root_default_action = VNode{S,A,O,L,U}(
+    solver.root = VNode{S,A,O,L,U}(
                         pomdp,
                         belief.particles,
                         solver.lb, 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -176,7 +176,7 @@ function trial{S,A,O,L,U}(solver::DESPOTSolver{S,A,O,L,U}, pomdp::POMDP{S,A,O}, 
     # another action, we need to check all actions - unlike the lower bound.
     node.ubound = -Inf
 
-    for a in iterator(actions(pomdp))
+    for a in iterator(actions(pomdp, node.particles))
         ubound = node.q_nodes[a].first_step_reward +
             discount(pomdp) * get_upper_bound(node.q_nodes[a])
         if ubound > node.ubound
@@ -206,7 +206,7 @@ function expand_one_step{S,A,O,L,U}(solver::DESPOTSolver{S,A,O}, pomdp::POMDP{S,
     remaining_reward::Float64 = 0.0
     rng = create_rng(solver.random_streams)
     
-    for curr_action in iterator(actions(pomdp))
+    for curr_action in iterator(actions(pomdp, node.particles))
         obs_to_particles = Dict{O,Vector{DESPOTParticle{S}}}()
 
         for p in node.particles
@@ -220,6 +220,7 @@ function expand_one_step{S,A,O,L,U}(solver::DESPOTSolver{S,A,O}, pomdp::POMDP{S,
                 rng,
                 curr_action)
             
+            #=
             if isterminal(pomdp, solver.next_state) && !isterminal_obs(pomdp, solver.curr_obs)
                 error("""
                       Terminal state in a particle mismatches observation.
@@ -227,6 +228,7 @@ function expand_one_step{S,A,O,L,U}(solver::DESPOTSolver{S,A,O}, pomdp::POMDP{S,
                       o: $(solver.curr_obs)
                       """)
             end
+            =#
 
             if !haskey(obs_to_particles, solver.curr_obs)
                 obs_to_particles[solver.curr_obs] = DESPOTParticle{S}[]

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,19 +1,19 @@
 import JSON
 import MCTS: AbstractTreeVisualizer, node_tag, tooltip_tag, create_json, blink
 
-type DESPOTTreeVisualizer <: AbstractTreeVisualizer
+type DESPOTVisualizer <: AbstractTreeVisualizer
     root::VNode
 end
 
-DESPOTTreeVisualizer(solver::DESPOTSolver) = DESPOTTreeVisualizer(solver.root)
+DESPOTVisualizer(solver::DESPOTSolver) = DESPOTVisualizer(solver.root)
 
-blink(solver::DESPOTSolver) = blink(DESPOTTreeVisualizer(solver))
+blink(solver::DESPOTSolver) = blink(DESPOTVisualizer(solver))
 
 typealias NodeDict Dict{Int, Dict{String, Any}}
 
-function create_json(v::DESPOTTreeVisualizer)
+function create_json(v::DESPOTVisualizer)
     node_dict = NodeDict()
-    dict = recursive_push!(node_dict, v.node, :root)
+    dict = recursive_push!(node_dict, v.root, :root)
     json = JSON.json(node_dict)
     return (json, 1)
 end
@@ -23,7 +23,7 @@ function recursive_push!(nd::NodeDict, n::VNode, obs, parent_id=-1)
     if parent_id > 0
         push!(nd[parent_id]["children_ids"], id)
     end
-    @assert n.n_visits=0
+    @assert n.n_visits==0
     nd[id] = Dict("id"=>id,
                   "type"=>:V,
                   "children_ids"=>Array(Int,0),
@@ -37,21 +37,22 @@ function recursive_push!(nd::NodeDict, n::VNode, obs, parent_id=-1)
     return nd
 end
 
-function recursive_push!(nd::NodeDict, n::QNode, parent_id=-1)
+function recursive_push!{S,A,O,L,U}(nd::NodeDict, n::QNode{S,A,O,L,U}, parent_id=-1)
     id = length(nd) + 1
     if parent_id > 0
         push!(nd[parent_id]["children_ids"], id)
     end
     nd[id] = Dict("id"=>id,
-                  "type"=>:Q,
+                  "type"=>:action,
                   "children_ids"=>Array(Int,0),
                   "tag"=>node_tag(n.action),
                   "tt_tag"=>tooltip_tag(n.action),
-                  "N"=>sum(length(v) for v in values(n.obs_to_particles)),
-                  "Q"=>"between $(get_lower_bound(n)) and $(get_upper_bound(n))"
+                  "N"=>sum(length(v.particles) for v in values(n.obs_to_node)),
+                  # "Q"=>"between $(get_lower_bound(n)) and $(get_upper_bound(n))"
+                  "Q"=>0.0
                   )
-    for (o,c) in n.children
-        recursive_push!(nd, c, id)
+    for (o,c) in n.obs_to_node
+        recursive_push!(nd, c, o, id)
     end
     return nd
 end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,0 +1,57 @@
+import JSON
+import MCTS: AbstractTreeVisualizer, node_tag, tooltip_tag, create_json, blink
+
+type DESPOTTreeVisualizer <: AbstractTreeVisualizer
+    root::VNode
+end
+
+DESPOTTreeVisualizer(solver::DESPOTSolver) = DESPOTTreeVisualizer(solver.root)
+
+blink(solver::DESPOTSolver) = blink(DESPOTTreeVisualizer(solver))
+
+typealias NodeDict Dict{Int, Dict{String, Any}}
+
+function create_json(v::DESPOTTreeVisualizer)
+    node_dict = NodeDict()
+    dict = recursive_push!(node_dict, v.node, :root)
+    json = JSON.json(node_dict)
+    return (json, 1)
+end
+
+function recursive_push!(nd::NodeDict, n::VNode, obs, parent_id=-1)
+    id = length(nd) + 1
+    if parent_id > 0
+        push!(nd[parent_id]["children_ids"], id)
+    end
+    @assert n.n_visits=0
+    nd[id] = Dict("id"=>id,
+                  "type"=>:V,
+                  "children_ids"=>Array(Int,0),
+                  "tag"=>node_tag(obs),
+                  "tt_tag"=>tooltip_tag(obs),
+                  "N"=>length(n.particles)
+                  )
+    for (a,c) in n.q_nodes
+        recursive_push!(nd, c, id)
+    end
+    return nd
+end
+
+function recursive_push!(nd::NodeDict, n::QNode, parent_id=-1)
+    id = length(nd) + 1
+    if parent_id > 0
+        push!(nd[parent_id]["children_ids"], id)
+    end
+    nd[id] = Dict("id"=>id,
+                  "type"=>:Q,
+                  "children_ids"=>Array(Int,0),
+                  "tag"=>node_tag(n.action),
+                  "tt_tag"=>tooltip_tag(n.action),
+                  "N"=>sum(length(v) for v in values(n.obs_to_particles)),
+                  "Q"=>"between $(get_lower_bound(n)) and $(get_upper_bound(n))"
+                  )
+    for (o,c) in n.children
+        recursive_push!(nd, c, id)
+    end
+    return nd
+end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -13,7 +13,7 @@ typealias NodeDict Dict{Int, Dict{String, Any}}
 
 function create_json(v::DESPOTVisualizer)
     node_dict = NodeDict()
-    dict = recursive_push!(node_dict, v.root, :root)
+    dict = recursive_push!(node_dict, v.root, "root (Q values at action nodes are upper bounds)")
     json = JSON.json(node_dict)
     return (json, 1)
 end
@@ -49,7 +49,7 @@ function recursive_push!{S,A,O,L,U}(nd::NodeDict, n::QNode{S,A,O,L,U}, parent_id
                   "tt_tag"=>tooltip_tag(n.action),
                   "N"=>sum(length(v.particles) for v in values(n.obs_to_node)),
                   # "Q"=>"between $(get_lower_bound(n)) and $(get_upper_bound(n))"
-                  "Q"=>0.0
+                  "Q"=>get_upper_bound(n)
                   )
     for (o,c) in n.obs_to_node
         recursive_push!(nd, c, o, id)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -37,7 +37,7 @@ function recursive_push!(nd::NodeDict, n::VNode, obs, parent_id=-1)
     return nd
 end
 
-function recursive_push!{S,A,O,L,U}(nd::NodeDict, n::QNode{S,A,O,L,U}, parent_id=-1)
+function recursive_push!{S,A,O,B}(nd::NodeDict, n::QNode{S,A,O,B}, parent_id=-1)
     id = length(nd) + 1
     if parent_id > 0
         push!(nd[parent_id]["children_ids"], id)

--- a/test/pomdps_compatibility_tests.jl
+++ b/test/pomdps_compatibility_tests.jl
@@ -8,7 +8,7 @@ import DESPOT: bounds
 immutable BabyBounds end
 bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p)), 0
 
-solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds}(bounds = BabyBounds(),
+solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds, MersenneStreamArray}(bounds = BabyBounds(),
                                                     random_streams=MersenneStreamArray(MersenneTwister(1)),
                                                     next_state=false,
                                                     curr_obs=false,
@@ -25,7 +25,7 @@ test_solver(solver, problem)
 immutable LightDarkBounds end
 bounds{S}(::LightDarkBounds, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p)), p.correct_r/(1.0-discount(p))
 
-solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkBounds}(bounds=LightDarkBounds(),
+solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkBounds, MersenneStreamArray}(bounds=LightDarkBounds(),
                                                                   random_streams=MersenneStreamArray(MersenneTwister(1)),
                                                                   next_state=LightDark1DState(0, 0.0),
                                                                   curr_obs=0.0

--- a/test/pomdps_compatibility_tests.jl
+++ b/test/pomdps_compatibility_tests.jl
@@ -26,10 +26,10 @@ test_solver(solver, problem, updater=updater(problem))
 test_solver(solver, problem)
 
 
-immutable LightDarkUB <: DESPOTUpperBound{LightDark1DState, Int64, Float64} end
+immutable LightDarkUB end
 upper_bound{S}(::LightDarkUB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.correct_r/(1.0-discount(p))
 
-immutable LightDarkLB <: DESPOTLowerBound{LightDark1DState, Int64, Float64} end
+immutable LightDarkLB end
 lower_bound{S}(::LightDarkLB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p))
 
 solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkLB, LightDarkUB}(ub=LightDarkUB(),

--- a/test/pomdps_compatibility_tests.jl
+++ b/test/pomdps_compatibility_tests.jl
@@ -10,9 +10,9 @@ bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfi
 
 solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds}(bounds = BabyBounds(),
                                                     random_streams=MersenneStreamArray(MersenneTwister(1)),
-                                                    root_default_action=false,
                                                     next_state=false,
-                                                    curr_obs=false
+                                                    curr_obs=false,
+                                                    rng=Base.GLOBAL_RNG
                                                     )
 problem = BabyPOMDP()
 
@@ -23,16 +23,11 @@ test_solver(solver, problem)
 
 
 immutable LightDarkBounds end
-upper_bound{S}(::LightDarkUB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.correct_r/(1.0-discount(p))
+bounds{S}(::LightDarkBounds, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p)), p.correct_r/(1.0-discount(p))
 
-immutable LightDarkLB end
-lower_bound{S}(::LightDarkLB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p))
-
-solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkLB, LightDarkUB}(ub=LightDarkUB(),
-                                                                  lb=LightDarkLB(),
+solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkBounds}(bounds=LightDarkBounds(),
                                                                   random_streams=MersenneStreamArray(MersenneTwister(1)),
-                                                                  root_default_action=false,
-                                                                  next_state=LightDark1DState(),
+                                                                  next_state=LightDark1DState(0, 0.0),
                                                                   curr_obs=0.0
                                                                  )
 

--- a/test/pomdps_compatibility_tests.jl
+++ b/test/pomdps_compatibility_tests.jl
@@ -24,8 +24,6 @@ problem = BabyPOMDP()
 # test_solver is from POMDPToolbox
 test_solver(solver, problem, updater=updater(problem))
 
-blink(solver)
-
 test_solver(solver, problem)
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,13 @@
 using Base.Test
 
-# uncomment below to include compatibility tests
-# include("pomdps_compatibility_tests.jl")
-
 if is_windows()
     error("This test is only valid on Linux and OS X platforms at this time") 
 end
 
 # Test on a simple RockSample problem
 include("../src/problems/RockSample/runRockSample.jl")
+
+include("pomdps_compatibility_tests.jl")
 include("test_with_other_particle_filter.jl")
 include("test_mersenne.jl")
 

--- a/test/test_mersenne.jl
+++ b/test/test_mersenne.jl
@@ -9,7 +9,9 @@ custom_bounds = RockSampleBounds(pomdp) # custom bounds for use with DESPOT solv
 solver = DESPOTSolver{RockSampleState,
                       RockSampleAction,
                       RockSampleObs,
-                      RockSampleBounds}(bounds = custom_bounds,
+                      RockSampleBounds,
+                      MersenneStreamArray
+                     }(bounds = custom_bounds,
                                         random_streams = MersenneStreamArray(MersenneTwister(2)) 
                                        )
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -8,7 +8,7 @@ import DESPOT: bounds
 immutable BabyBounds end
 bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p)), 0
 
-solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds}(bounds = BabyBounds(),
+solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds, MersenneStreamArray}(bounds = BabyBounds(),
                                                     random_streams=MersenneStreamArray(MersenneTwister(1)),
                                                     next_state=false,
                                                     curr_obs=false,

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -3,22 +3,18 @@ using DESPOT
 using POMDPToolbox
 using POMDPModels
 
-import DESPOT: upper_bound, lower_bound
+import DESPOT: bounds
 
-# Note: init_lower_bound and init_upper_bound should have a default implementation that does nothing
-immutable BabyUB end
-upper_bound{S}(::BabyUB, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = 0
+immutable BabyBounds end
+bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p)), 0
 
-immutable BabyLB end
-lower_bound{S}(::BabyLB, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p))
-
-solver = DESPOTSolver{Bool, Bool, Bool, BabyLB, BabyUB}(ub = BabyUB(),
-                                                        lb = BabyLB(),
-                                                        random_streams=MersenneStreamArray(MersenneTwister(1)),
-                                                        root_default_action=false,
-                                                        next_state=false,
-                                                        curr_obs=false
-                                                       )
+solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds}(bounds = BabyBounds(),
+                                                    random_streams=MersenneStreamArray(MersenneTwister(1)),
+                                                    next_state=false,
+                                                    curr_obs=false,
+                                                    rng=Base.GLOBAL_RNG,
+                                                    max_trials=100
+                                                    )
 problem = BabyPOMDP()
 
 # test_solver is from POMDPToolbox

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -25,22 +25,3 @@ problem = BabyPOMDP()
 test_solver(solver, problem, updater=updater(problem))
 
 blink(solver)
-
-test_solver(solver, problem)
-
-
-immutable LightDarkUB end
-upper_bound{S}(::LightDarkUB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.correct_r/(1.0-discount(p))
-
-immutable LightDarkLB end
-lower_bound{S}(::LightDarkLB, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p))
-
-solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkLB, LightDarkUB}(ub=LightDarkUB(),
-                                                                  lb=LightDarkLB(),
-                                                                  random_streams=MersenneStreamArray(MersenneTwister(1)),
-                                                                  root_default_action=false,
-                                                                  next_state=LightDark1DState(),
-                                                                  curr_obs=0.0
-                                                                 )
-
-test_solver(solver, LightDark1D())

--- a/test/test_with_other_particle_filter.jl
+++ b/test/test_with_other_particle_filter.jl
@@ -9,7 +9,8 @@ custom_bounds = RockSampleBounds(pomdp) # custom lower bound to use with DESPOT 
 solver = DESPOTSolver{RockSampleState,
                       RockSampleAction,
                       RockSampleObs,
-                      RockSampleBounds}(bounds = custom_bounds)
+                      RockSampleBounds,
+                      RandomStreams}(bounds = custom_bounds)
 
 policy = solve(solver, pomdp)
 


### PR DESCRIPTION
This PR adds broad compatibility with other POMDPs.jl problems (see test/pomdps_compatibility_tests.jl)

The original RockSample tests also pass as before.

It also contains tree visualization.

A quick comparison shows no reduction in performance:

old master:
```
================= Batch Averages =================
Number of steps = 11
Discounted return = 20.00
Undiscounted return = 12.62
Runtime = 6.27 sec
DESPOT/RockSample(4,4) batch test status: PASSED

# runtime for the Rocksample(5,6) test
17.981104559
```

code in this PR:
```
================= Batch Averages =================
Number of steps = 11
Discounted return = 20.00
Undiscounted return = 12.62
Runtime = 6.24 sec
DESPOT/RockSample(4,4) batch test status: PASSED

# runtime for the Rocksample(5,6) test
15.917098038
```

There are two very minor caveats
1. I moved the calculations for the default action out of the `VNode` constructor and into the `search()` function. This means that, in the *rare* case that the default action is used, the lower bound calculations will be repeated and not reused.
2. The solver is parameterized by the random_streams type (for performance) so that has to be typed out every time a solver is created. I think all of the parameters could be removed from the solver type by cleverly parameterizing other objects or by creating more outer constructors, but that would require some rewriting