### PR TITLE
Switched from a dictionary to a vector for Q node children

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -11,6 +11,7 @@ type DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
     curr_reward::DESPOTReward
     next_state::S
     curr_obs::O
+    print_bounds::Bool
 
     # default constructor
     function DESPOTSolver(  ;
@@ -30,7 +31,8 @@ type DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
                             debug::Int64 = 0,
                             random_streams::RS = RandomStreams(n_particles, search_depth, main_seed),
                             next_state = S(),
-                            curr_obs = O()
+                            curr_obs = O(),
+                            print_bounds = false
                            )
 
         this = new()
@@ -57,6 +59,7 @@ type DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
         this.curr_obs = curr_obs
         this.curr_reward = 0.0
         this.random_streams = random_streams
+        this.print_bounds = print_bounds
         return this
     end
 end
@@ -93,7 +96,9 @@ function search{S,A,O,B}(solver::DESPOTSolver{S,A,O,B}, pomdp::POMDP{S,A,O})
     start_time::Float64 = time()
     stop_now::Bool = false
     
-    @printf("Before: lBound = %.10f, uBound = %.10f\n", solver.root.lbound, solver.root.ubound)
+    if solver.print_bounds
+        @printf("Before: lBound = %.10f, uBound = %.10f\n", solver.root.lbound, solver.root.ubound)
+    end
                                 
     while ((excess_uncertainty(solver.root.lbound,
                                 solver.root.ubound,
@@ -112,8 +117,10 @@ function search{S,A,O,B}(solver::DESPOTSolver{S,A,O,B}, pomdp::POMDP{S,A,O})
         end
     end
 
-    @printf("After:  lBound = %.10f, uBound = %.10f\n", solver.root.lbound, solver.root.ubound)
-    @printf("Number of trials: %d\n", n_trials)
+    if solver.print_bounds
+        @printf("After:  lBound = %.10f, uBound = %.10f\n", solver.root.lbound, solver.root.ubound)
+        @printf("Number of trials: %d\n", n_trials)
+    end
 
     if solver.config.pruning_constant != 0.0
         total_pruned = prune(solver.root) # Number of non-child belief nodes pruned

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -152,17 +152,19 @@ function trial{S,A,O,B}(solver::DESPOTSolver{S,A,O,B}, pomdp::POMDP{S,A,O}, node
 
     a_star::A = node.best_ub_action
 
-    o_star::O, weighted_eu_star::Float64 =
+    i_star::Int, weighted_eu_star::Float64 =
                                get_best_weuo(node.q_nodes[a_star],
                                              solver.root,
                                              solver.config,
                                              discount(pomdp)) # it's an array!
     
+    o_star, vnode_star = node.q_nodes[a_star].obs_and_nodes[i_star]
+
     if weighted_eu_star > 0.0
         add(solver.belief.history, a_star, o_star)
         n_nodes_added = trial(solver,
                             pomdp,
-                            node.q_nodes[a_star].obs_to_node[o_star],
+                            vnode_star,
                             n_trials) 
         remove_last(solver.belief.history)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,9 +23,9 @@ function get_best_weuo{S,A,O,B}(qnode::QNode{S,A,O,B},
                        config::DESPOTConfig,
                        discount::Float64)
   weighted_eu_star::Float64 = -Inf
-  oStar = collect(keys(qnode.obs_to_node))[1] # init with something
+  istar = 1
   
-  for (obs,node) in qnode.obs_to_node
+  for (i, (obs,node)) in enumerate(qnode.obs_and_nodes)
         weighted_eu = node.weight / qnode.weight_sum *
                             excess_uncertainty(node.lbound,
                                                node.ubound,
@@ -37,12 +37,15 @@ function get_best_weuo{S,A,O,B}(qnode::QNode{S,A,O,B},
 
         if weighted_eu > weighted_eu_star
             weighted_eu_star = weighted_eu
-            oStar = obs
+            istar = i
         end
   end
-  return oStar, weighted_eu_star
+  return istar, weighted_eu_star
 end
 
+
+# XXX these functions will not work after the change to obs_to_node, but they do not appear to be used in the core algorithm
+#=
 # Get WEUO for a single observation branch
 function get_node_weuo{S,A,O,B}(qnode::QNode{S,A,O,B}, root::VNode{S,A,O,B}, obs::Int64)
    weighted_eu = qnode.obs_to_node[obs].weight / qnode.weight_sum *
@@ -57,6 +60,7 @@ end
 function belief{S,A,O,B}(qnode::QNode{S,A,O,B}, obs::O)
   return qnode.obs_to_node[obs]
 end
+=#
 
 function validate_bounds(lb::Float64, ub::Float64, config::DESPOTConfig)
   if (ub >= lb)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -47,11 +47,11 @@ function recursive_push!{S,A,O,B}(nd::NodeDict, n::QNode{S,A,O,B}, parent_id=-1)
                   "children_ids"=>Array(Int,0),
                   "tag"=>node_tag(n.action),
                   "tt_tag"=>tooltip_tag(n.action),
-                  "N"=>sum(length(v.particles) for v in values(n.obs_to_node)),
+                  "N"=>sum(length(last(pair).particles) for pair in n.obs_and_nodes),
                   # "Q"=>"between $(get_lower_bound(n)) and $(get_upper_bound(n))"
                   "Q"=>get_upper_bound(n)
                   )
-    for (o,c) in n.obs_to_node
+    for (o,c) in n.obs_and_nodes
         recursive_push!(nd, c, o, id)
     end
     return nd

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+POMDPModels


### PR DESCRIPTION
Iterating through the obs_to_node dictionary is slow for large observation spaces. I replaced this dictionary with a vector. This causes a 60% speedup for a continuous observation problem. Eventually we should replace the get_upper_bound sum with some kind of incremental update because it is taking the majority of time for problems with large observation spaces.