### PR TITLE
changes to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.5
+  - 0.6
 notifications:
   email: false
 before_script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 POMDPs 0.4
 Distributions
 JSON

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,4 +1,4 @@
-type DESPOTConfig
+mutable struct DESPOTConfig
   # Maximum depth of the search tree
   search_depth::Int64
   # Random-number seed
@@ -21,10 +21,10 @@ type DESPOTConfig
 #   particle_weight_threshold::Float64
 #   eff_particle_fraction::Float64
   tiny::Float64 # tiny number
-  max_trials::Int64 
-  rand_max::Int64 
+  max_trials::Int64
+  rand_max::Int64
   debug::UInt8
-  
+
   # construct empty
   function DESPOTConfig()
    this = new()

--- a/src/history.jl
+++ b/src/history.jl
@@ -1,13 +1,13 @@
-type History{A,O}
+mutable struct History{A,O}
     actions::Vector{A}
     observations::Vector{O}
-    History() = new(Array(A, 0), Array(O, 0))
+    History{A,O}() where {A,O} = new(Array{A}(0), Array{O}(0))
 end
 
 function add{A,O}(history::History{A,O},
             action::A,
             obs::O)
-    
+
     push!(history.actions, action)
     push!(history.observations, obs)
 end

--- a/src/lowerBound/DESPOTDefaultLowerBound.jl
+++ b/src/lowerBound/DESPOTDefaultLowerBound.jl
@@ -1,14 +1,14 @@
 import DESPOT:
         lower_bound
 
-type DESPOTDefaultLowerBound
+mutable struct DESPOTDefaultLowerBound
     #placeholder for now
 end
 
 function init_bound{S,A,O}(ub::DESPOTDefaultLowerBound,
                     pomdp::POMDP{S,A,O},
                     config::DESPOTConfig)
-    error("Function init_bound for $(typeof(ub)) has not been implemented yet")                    
+    error("Function init_bound for $(typeof(ub)) has not been implemented yet")
 end
 
 function lower_bound{S,A,O}(lb::DESPOTDefaultLowerBound,

--- a/src/problems/RockSample/rockSampleBounds.jl
+++ b/src/problems/RockSample/rockSampleBounds.jl
@@ -5,10 +5,10 @@ include("../../upperBound/upperBoundNonStochastic.jl")
 
 import DESPOT: bounds, init_bounds, default_action
 
-type RockSampleBounds
+mutable struct RockSampleBounds
     lb::RockSampleParticleLB
     ub::UpperBoundNonStochastic{RockSampleState,RockSampleAction,RockSampleObs}
-    
+
     function RockSampleBounds(pomdp::RockSample)
         this = new()
         this.lb = RockSampleParticleLB(pomdp)
@@ -22,10 +22,10 @@ function bounds(b::RockSampleBounds,
        pomdp::RockSample,
        particles::Vector{DESPOTParticle{RockSampleState}},
        config::DESPOTConfig)
-       
+
     ubound::Float64 = upper_bound(b.ub, pomdp, particles, config)
     lbound::Float64 = lower_bound(b.lb, pomdp, particles, b.ub.upper_bound_act, config)
-       
+
     return lbound, ubound
 end
 

--- a/src/randomStreams.jl
+++ b/src/randomStreams.jl
@@ -14,7 +14,7 @@ set_rng_state!(rng::AbstractRNG, ::Stream, scenario::Int, depth::Int) is called 
 # transitions during simulations. It also provides random-number seeds
 # for different components of the system.
 
-type RandomStreams
+mutable struct RandomStreams
     num_streams::Int64
     len_streams::Int64
     streams::Array{Float64,2}     # each particle is associated with a single stream of numbers
@@ -24,25 +24,25 @@ type RandomStreams
   function RandomStreams(num_streams::Int64,
                 len_streams::Int64,
                 seed::UInt32)
-          this = new() 
-          
+          this = new()
+
           this.num_streams = num_streams
           this.len_streams = len_streams
-          this.streams = Array(Float64, num_streams, len_streams)
+          this.streams = Array{Float64}(num_streams, len_streams)
           this.seed = seed
-          
+
           return this
     end
 end
 
 get_stream_seed(streams::RandomStreams, streamId::UInt32) =
-    streams.seed $ streamId # bitwise XOR
+    streams.seed ⊻ streamId # bitwise XOR
 
 get_world_seed(streams::RandomStreams) =
-    streams.seed $ streams.num_streams
+    streams.seed ⊻ streams.num_streams
 
 get_model_seed(streams::RandomStreams) =
-    streams.seed $ (streams.num_streams + 2)
+    streams.seed ⊻ (streams.num_streams + 2)
 
 function fill_random_streams!(empty_streams::RandomStreams, rand_max::Int64)
     # Populate random streams
@@ -61,7 +61,7 @@ function fill_random_streams!(empty_streams::RandomStreams, rand_max::Int64)
             srand(seed)
             empty_streams.streams[i,:] = Base.rand(convert(Int64, empty_streams.len_streams))
         end
-    end  
+    end
 end
 
 function set_rng_state!(rng::DESPOTRandomNumber, rs::RandomStreams, scenario::Int, depth::Int)
@@ -73,7 +73,7 @@ create_rng(::RandomStreams) = DESPOTRandomNumber(-1)
 
 ### MersenneTwister Streams ###
 
-type MersenneStreamArray
+mutable struct MersenneStreamArray
     rng::AbstractRNG
     streams::Vector{Vector{MersenneTwister}}
 end

--- a/src/upperBound/DESPOTDefaultUpperBound.jl
+++ b/src/upperBound/DESPOTDefaultUpperBound.jl
@@ -1,11 +1,11 @@
-type DESPOTDefaultUpperBound <: DESPOTUpperBound
+mutable struct DESPOTDefaultUpperBound <: DESPOTUpperBound
     #placeholder for now
 end
 
 function init_bound(ub::UpperBoundNonStochastic,
                     pomdp::POMDP,
                     config::DESPOTConfig)
-    error("Function init_bound for $(typeof(ub)) has not been implemented yet")                    
+    error("Function init_bound for $(typeof(ub)) has not been implemented yet")
 end
 
 function lower_bound(lb::DESPOTDefaultUpperBound,

--- a/src/upperBound/upperBoundNonStochastic.jl
+++ b/src/upperBound/upperBoundNonStochastic.jl
@@ -1,12 +1,12 @@
 
 
-type UpperBoundNonStochastic{S,A,O}
+mutable struct UpperBoundNonStochastic{S,A,O}
     upper_bound_act::Vector{A}
     upper_bound_memo::Vector{Float64}
-    
+
     # Constructor
-    function UpperBoundNonStochastic(pomdp::POMDP{S,A,O})    
-        this = new()       
+    function UpperBoundNonStochastic(pomdp::POMDP{S,A,O})
+        this = new()
         # this executes just once per problem run
         this.upper_bound_act = Array{A}(n_states(pomdp))    # upper_bound_act
         this.upper_bound_memo = Array{Float64}(n_states(pomdp)) # upper_bound_memo
@@ -14,31 +14,31 @@ type UpperBoundNonStochastic{S,A,O}
     end
 end
 
-fringe_upper_bound{S,A,O}(pomdp::POMDP{S,A,O}, state::S) = 
+fringe_upper_bound{S,A,O}(pomdp::POMDP{S,A,O}, state::S) =
     error("$(typeof(pomdp)) does not implement fringe_upper_bound")
 
 function init_bound{S,A,O}(ub::UpperBoundNonStochastic{S,A,O},
                     pomdp::POMDP{S,A,O},
                     config::DESPOTConfig)
-                    
+
 # function DESPOT.init_upper_bound{S,A,O}(ub::UpperBoundNonStochastic{S,A,O},
 #                     pomdp::POMDP{S,A,O},
 #                     config::DESPOTConfig)
-    
-    current_level_ub_memo = Array(Float64, n_states(pomdp))
-    next_level_ub_memo = Array(Float64, n_states(pomdp))
-    
+
+    current_level_ub_memo = Array{Float64}(n_states(pomdp))
+    next_level_ub_memo = Array{Float64}(n_states(pomdp))
+
     next_state = S()
     r::Float64 = 0.0
     trans_distribution = create_transition_distribution(pomdp)
     rng = DESPOTRandomNumber(0) # dummy RNG
-    
+
     fill!(current_level_ub_memo, -Inf)
-    
+
     for s in iterator(states(pomdp))
         next_level_ub_memo[state_index(pomdp,s)+1] = fringe_upper_bound(pomdp,s) # 1-based indexing
     end
-    
+
     for i in 1:config.search_depth # length of horizon
         for s in iterator(states(pomdp))
             for a in iterator(actions(pomdp))
@@ -46,7 +46,7 @@ function init_bound{S,A,O}(ub::UpperBoundNonStochastic{S,A,O},
                 trans_distribution.action = a
                 next_state = POMDPs.rand(rng, trans_distribution, next_state)
                 r = reward(pomdp, s, a)
-                possibly_improved_value = 
+                possibly_improved_value =
                     r + pomdp.discount * next_level_ub_memo[state_index(pomdp,next_state)+1]
                 if (possibly_improved_value > current_level_ub_memo[state_index(pomdp,s)+1])
                     current_level_ub_memo[state_index(pomdp,s)+1] = possibly_improved_value
@@ -57,19 +57,19 @@ function init_bound{S,A,O}(ub::UpperBoundNonStochastic{S,A,O},
                 end
             end # for a
         end # for s
-        
+
         # swap array references
         tmp = current_level_ub_memo
         current_level_ub_memo = next_level_ub_memo
         next_level_ub_memo = tmp
-        
+
         fill!(current_level_ub_memo,-Inf)
     end
 
     #TODO: this can probably be done more optimally (by referencing upper_bound_memo to start with),
     # however, this only runs once per problem and is probably not a big deal. Leave it as is for now.
     copy!(ub.upper_bound_memo, next_level_ub_memo)
-    
+
     return nothing
 end
 
@@ -86,4 +86,3 @@ function upper_bound{S,A,O}(ub::UpperBoundNonStochastic{S,A,O},
   end
   return total_cost / weight_sum
 end
-

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,7 +1,7 @@
 import JSON
 import MCTS: AbstractTreeVisualizer, node_tag, tooltip_tag, create_json, blink
 
-type DESPOTVisualizer <: AbstractTreeVisualizer
+mutable struct DESPOTVisualizer <: AbstractTreeVisualizer
     root::VNode
 end
 
@@ -9,7 +9,7 @@ DESPOTVisualizer(solver::DESPOTSolver) = DESPOTVisualizer(solver.root)
 
 blink(solver::DESPOTSolver) = blink(DESPOTVisualizer(solver))
 
-typealias NodeDict Dict{Int, Dict{String, Any}}
+const NodeDict = Dict{Int, Dict{String, Any}}
 
 function create_json(v::DESPOTVisualizer)
     node_dict = NodeDict()
@@ -26,7 +26,7 @@ function recursive_push!(nd::NodeDict, n::VNode, obs, parent_id=-1)
     @assert n.n_visits==0
     nd[id] = Dict("id"=>id,
                   "type"=>:V,
-                  "children_ids"=>Array(Int,0),
+                  "children_ids"=>Array{Int}(0),
                   "tag"=>node_tag(obs),
                   "tt_tag"=>tooltip_tag(obs),
                   "N"=>length(n.particles)
@@ -44,7 +44,7 @@ function recursive_push!{S,A,O,B}(nd::NodeDict, n::QNode{S,A,O,B}, parent_id=-1)
     end
     nd[id] = Dict("id"=>id,
                   "type"=>:action,
-                  "children_ids"=>Array(Int,0),
+                  "children_ids"=>Array{Int}(0),
                   "tag"=>node_tag(n.action),
                   "tt_tag"=>tooltip_tag(n.action),
                   "N"=>sum(length(last(pair).particles) for pair in n.obs_and_nodes),

--- a/test/pomdps_compatibility_tests.jl
+++ b/test/pomdps_compatibility_tests.jl
@@ -5,7 +5,7 @@ using POMDPModels
 
 import DESPOT: bounds
 
-immutable BabyBounds end
+struct BabyBounds end
 bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p)), 0
 
 solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds, MersenneStreamArray}(bounds = BabyBounds(),
@@ -22,7 +22,7 @@ test_solver(solver, problem, updater=updater(problem))
 test_solver(solver, problem)
 
 
-immutable LightDarkBounds end
+struct LightDarkBounds end
 bounds{S}(::LightDarkBounds, p::LightDark1D, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = p.incorrect_r/(1.0-discount(p)), p.correct_r/(1.0-discount(p))
 
 solver = DESPOTSolver{LightDark1DState, Int64, Float64, LightDarkBounds, MersenneStreamArray}(bounds=LightDarkBounds(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Base.Test
 
 if is_windows()
-    error("This test is only valid on Linux and OS X platforms at this time") 
+    error("This test is only valid on Linux and OS X platforms at this time")
 end
 
 # Test on a simple RockSample problem
@@ -28,7 +28,7 @@ debug                   = 0
 grid_size               = 4
 num_rocks               = 4
 
-# The return values below are batch averages 
+# The return values below are batch averages
 sim_steps, undiscounted_return, discounted_return, run_time =
                 main(
                     grid_size = grid_size,
@@ -38,7 +38,7 @@ sim_steps, undiscounted_return, discounted_return, run_time =
                     discount = discount,
                     search_depth = search_depth,
                     time_per_move = time_per_move,
-                    pruning_constant = pruning_constant, 
+                    pruning_constant = pruning_constant,
                     eta = eta,
                     sim_len = sim_len,
                     max_trials = max_trials,
@@ -49,22 +49,22 @@ sim_steps, undiscounted_return, discounted_return, run_time =
 
 #println(sim_steps, undiscounted_return, discounted_return, run_time)
 if is_linux()
-    @test               sim_steps == 11
-    @test_approx_eq_eps discounted_return 12.62 1e-2
-    @test               undiscounted_return == 20.00
+    @test sim_steps == 11
+    @test discounted_return ≈ 12.62 atol=1e-2
+    @test undiscounted_return == 20.00
 end
 # osx tests
 if is_apple()
-    @test               sim_steps == 11
-    @test_approx_eq_eps discounted_return 12.97 1e-2
-    @test               undiscounted_return == 20.00
+    @test sim_steps == 11
+    @test discounted_return ≈ 12.97 atol=1e-2
+    @test undiscounted_return == 20.00
 end
 
 println("DESPOT/RockSample(4,4) batch test status: PASSED")
 
 
 
-# Non-standard RockSample(5,6) test 
+# Non-standard RockSample(5,6) test
 # (non-standard means that the initial state space is generated programmatically)
 
 grid_size               = 5
@@ -78,7 +78,7 @@ sim_steps, undiscounted_return, discounted_return, run_time =
                     discount = discount,
                     search_depth = search_depth,
                     time_per_move = time_per_move,
-                    pruning_constant = pruning_constant, 
+                    pruning_constant = pruning_constant,
                     eta = eta,
                     sim_len = sim_len,
                     max_trials = max_trials,
@@ -88,15 +88,15 @@ sim_steps, undiscounted_return, discounted_return, run_time =
 
 println(sim_steps, undiscounted_return, discounted_return, run_time)
 if is_linux()
-    @test               sim_steps == 21
-    @test_approx_eq_eps discounted_return 28.97 1e-2
-    @test               undiscounted_return == 50.00
+    @test sim_steps == 21
+    @test discounted_return ≈ 28.97 atol=1e-2
+    @test undiscounted_return == 50.00
 end
 # osx tests
 if is_apple()
-    @test               sim_steps == 20
-    @test_approx_eq_eps discounted_return 20.80 1e-2
-    @test               undiscounted_return == 40.00
+    @test sim_steps == 20
+    @test discounted_return ≈ 20.80 atol=1e-2
+    @test undiscounted_return == 40.00
 end
 
 println("DESPOT/RockSample(5,6) test status: PASSED")
@@ -116,7 +116,7 @@ sim_steps, undiscounted_return, discounted_return, run_time =
                     discount = discount,
                     search_depth = search_depth,
                     time_per_move = time_per_move,
-                    pruning_constant = pruning_constant, 
+                    pruning_constant = pruning_constant,
                     eta = eta,
                     sim_len = sim_len,
                     max_trials = max_trials,
@@ -128,15 +128,15 @@ sim_steps, undiscounted_return, discounted_return, run_time =
 
 
 if is_linux()
-    @test               sim_steps == 32
-    @test_approx_eq_eps discounted_return 24.82 1e-2
-    @test               undiscounted_return == 50.00
+    @test sim_steps == 32
+    @test discounted_return ≈ 24.82 atol=1e-2
+    @test undiscounted_return == 50.00
 end
 # osx tests
 if is_apple()
-    @test               sim_steps == 30
-    @test_approx_eq_eps discounted_return 16.98 1e-2
-    @test               undiscounted_return == 40.00
+    @test sim_steps == 30
+    @test discounted_return ≈ 16.98 atol=1e-2
+    @test undiscounted_return == 40.00
 end
 
 println("DESPOT/RockSample(7,8) test status: PASSED")
@@ -155,7 +155,7 @@ sim_steps, undiscounted_return, discounted_return, run_time =
                     discount = discount,
                     search_depth = search_depth,
                     time_per_move = time_per_move,
-                    pruning_constant = pruning_constant, 
+                    pruning_constant = pruning_constant,
                     eta = eta,
                     sim_len = sim_len,
                     max_trials = max_trials,
@@ -165,15 +165,15 @@ sim_steps, undiscounted_return, discounted_return, run_time =
 
 #println(sim_steps, undiscounted_return, discounted_return, run_time)
 if is_linux()
-    @test               sim_steps == 50
-    @test_approx_eq_eps discounted_return 21.24 1e-2
-    @test               undiscounted_return == 60.00
+    @test sim_steps == 50
+    @test discounted_return ≈ 21.24 atol=1e-2
+    @test undiscounted_return == 60.00
 end
 # osx tests
 if is_apple()
-    @test               sim_steps == 45
-    @test_approx_eq_eps discounted_return 13.5 1e-2
-    @test               undiscounted_return == 40.00
+    @test sim_steps == 45
+    @test discounted_return ≈ 13.5 atol=1e-2
+    @test undiscounted_return == 40.00
 end
 
 println("DESPOT/RockSample(11,11) test status: PASSED")

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -5,7 +5,7 @@ using POMDPModels
 
 import DESPOT: bounds
 
-immutable BabyBounds end
+struct BabyBounds end
 bounds{S}(::BabyBounds, p::BabyPOMDP, ::Vector{DESPOTParticle{S}}, ::DESPOTConfig) = (p.r_feed+p.r_hungry)/(1.0-discount(p)), 0
 
 solver = DESPOTSolver{Bool, Bool, Bool, BabyBounds, MersenneStreamArray}(bounds = BabyBounds(),


### PR DESCRIPTION
I updated the code to run in julia 0.6. It was only syntax changes, the tests pass with deprecation warning that should be fixed later:
- Inner constructor syntax (new() is not valid anymore for parametric type)
- POMDPToolbox.ParticleBelief is deprecated

Note: I tested with the updated version (see branch 0_6) of POMDPs and POMDPToolbox
