### PR TITLE
eliminated deprecated inner constructor syntax

### DIFF
--- a/src/beliefUpdate/beliefUpdateParticle.jl
+++ b/src/beliefUpdate/beliefUpdateParticle.jl
@@ -20,7 +20,7 @@ mutable struct DESPOTBeliefUpdater{S,A,O} <: POMDPs.Updater
     obs_probability::Float64
 
     #default constructor
-    function DESPOTBeliefUpdater(pomdp::POMDP{S,A,O};
+    function DESPOTBeliefUpdater{S,A,O}(pomdp::POMDP{S,A,O};
                                  seed::UInt32 = convert(UInt32, 42),
                                  rand_max::Int64 = 2147483647,
                                  n_particles = 500,
@@ -29,7 +29,7 @@ mutable struct DESPOTBeliefUpdater{S,A,O} <: POMDPs.Updater
                                  next_state::S = S(),
                                  observation::O = O(),
                                  rng::AbstractRNG=DESPOTDefaultRNG(convert(UInt32, seed ⊻ (n_particles+1)), rand_max)
-                                )
+                                ) where {S,A,O}
         this = new()
         this.pomdp = pomdp
         this.num_updates = 0

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -27,7 +27,7 @@ mutable struct _QNode{S,A,O,B,T} #Workaround to achieve a circular type definiti
     bounds::B
 
       # default constructor
-      function _QNode(
+      function _QNode{S,A,O,B,T}(
                     pomdp::POMDP{S,A,O},
                     bounds::B,
                     obs_to_particles::Dict{O,Vector{DESPOTParticle{S}}},
@@ -35,7 +35,7 @@ mutable struct _QNode{S,A,O,B,T} #Workaround to achieve a circular type definiti
                     action::A,
                     first_step_reward::Float64,
                     history::History{A,O},
-                    config::DESPOTConfig)
+                    config::DESPOTConfig) where {S,A,O,B,T}
 
             this = new()
             this.obs_to_particles = obs_to_particles
@@ -100,14 +100,14 @@ mutable struct VNode{S,A,O,B}
   q_star::Float64                   # best current Q-value, needed for large domains
 
   # default constructor
-  function VNode(
+  function VNode{S,A,O,B}(
                pomdp::POMDP{S,A,O},
                particles::Vector{DESPOTParticle{S}},
                b::B,
                depth::Int64,
                weight::Float64,
                in_tree::Bool,
-               config::DESPOTConfig)
+               config::DESPOTConfig) where {S,A,O,B}
 
         this = new()
         this.particles          = particles

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -14,7 +14,7 @@ mutable struct DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
     print_bounds::Bool
 
     # default constructor
-    function DESPOTSolver(  ;
+    function DESPOTSolver{S,A,O,B,RS}(  ;
                             bounds::B = B(), #TODO: fix
                             rng::AbstractRNG = Base.GLOBAL_RNG,
                             search_depth::Int64 = 90,
@@ -33,7 +33,7 @@ mutable struct DESPOTSolver{S,A,O,B,RS} <: POMDPs.Solver
                             next_state = S(),
                             curr_obs = O(),
                             print_bounds = false
-                           )
+                           ) where {S,A,O,B,RS}
 
         this = new()
 

--- a/src/upperBound/upperBoundNonStochastic.jl
+++ b/src/upperBound/upperBoundNonStochastic.jl
@@ -5,7 +5,7 @@ mutable struct UpperBoundNonStochastic{S,A,O}
     upper_bound_memo::Vector{Float64}
 
     # Constructor
-    function UpperBoundNonStochastic(pomdp::POMDP{S,A,O})
+    function UpperBoundNonStochastic{S,A,O}(pomdp::POMDP{S,A,O}) where {S,A,O}
         this = new()
         # this executes just once per problem run
         this.upper_bound_act = Array{A}(n_states(pomdp))    # upper_bound_act


### PR DESCRIPTION
Eliminated the deprecation warning from transitioning to 0.6 (I think these may have been slowing things down a little).